### PR TITLE
Example implementation of `int f() { return 5; }`

### DIFF
--- a/include/ast/ast_functions.hpp
+++ b/include/ast/ast_functions.hpp
@@ -60,7 +60,74 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        std::cerr << "Function: compile is not implemented." << std::endl;
+        std::cerr << "Function: evaluate is not fully implemented." << std::endl;
+
+        dst << "# Function: evaluate is not fully implemented" << std::endl;
+        dst << ".text" << std::endl;
+        dst << ".globl " << name << std::endl;
+        dst << std::endl;
+
+        dst << name << ":" << std::endl;
+
+        if (body != nullptr)
+        {
+            body->compile(ctx, dst);
+        }
+
+        // Implicit return at the end of the function, in case it was not
+        // specified in the body.
+        dst << "li a0, 0" << std::endl;
+        dst << "ret" << std::endl;
+    }
+};
+
+class Return
+    : public Expression
+{
+private:
+    ExpressionPtr returnExpr;
+
+public:
+    Return()
+        : returnExpr(nullptr)
+    {
+    }
+
+    Return(ExpressionPtr _returnExpr)
+        : returnExpr(_returnExpr)
+    {
+    }
+
+    virtual ~Return()
+    {
+        delete returnExpr;
+    }
+
+    ExpressionPtr getReturnExpression() const
+    {
+        return returnExpr;
+    }
+
+    virtual void print(std::ostream &dst) const override
+    {
+        dst << "return";
+        if (returnExpr == nullptr)
+        {
+            dst << ";" << std::endl;
+            return;
+        }
+
+        dst << " ";
+        returnExpr->print(dst);
+    }
+
+    virtual void compile(Context &ctx, std::ostream &dst) const override
+    {
+        if (returnExpr != nullptr)
+        {
+            returnExpr->compile(ctx, dst);
+        }
+        dst << "ret" << std::endl;
     }
 };
 

--- a/include/ast/ast_primitives.hpp
+++ b/include/ast/ast_primitives.hpp
@@ -4,14 +4,14 @@
 #include <string>
 #include <iostream>
 
-class Variable
+class Identifier
     : public Expression
 {
 private:
     std::string id;
 
 public:
-    Variable(const std::string &_id)
+    Identifier(const std::string &_id)
         : id(_id)
     {
     }
@@ -28,7 +28,6 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        std::cerr << "Variable: compile is not implemented" << std::endl;
     }
 };
 
@@ -36,10 +35,10 @@ class Number
     : public Expression
 {
 private:
-    double value;
+    long double value;
 
 public:
-    Number(double _value)
+    Number(long double _value)
         : value(_value)
     {
     }
@@ -56,7 +55,8 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        std::cerr << "Number: compile is not implemented" << std::endl;
+        std::cerr << "Assuming all numbers are integers" << std::endl;
+        dst << "li a0, " << int(value) << std::endl;
     }
 };
 

--- a/src/c90_lexer.flex
+++ b/src/c90_lexer.flex
@@ -62,14 +62,14 @@ int check_type();
     return check_type();
 }
 
-0[xX]{H}+{IS}?		{ count(); return(CONSTANT); }
-0{D}+{IS}?		    { count(); return(CONSTANT); }
-{D}+{IS}?		    { count(); return(CONSTANT); }
+0[xX]{H}+{IS}?		{ count(); yylval.str = new std::string(yytext); return(CONSTANT); }
+0{D}+{IS}?		    { count(); yylval.str = new std::string(yytext); return(CONSTANT); }
+{D}+{IS}?		    { count(); yylval.str = new std::string(yytext); return(CONSTANT); }
 L?'(\\.|[^\\'])+'	{ count(); return(CONSTANT); }
 
-{D}+{E}{FS}?		    { count(); return(CONSTANT); }
-{D}*"."{D}+({E})?{FS}?	{ count(); return(CONSTANT); }
-{D}+"."{D}*({E})?{FS}?	{ count(); return(CONSTANT); }
+{D}+{E}{FS}?		    { count(); yylval.str = new std::string(yytext); return(CONSTANT); }
+{D}*"."{D}+({E})?{FS}?	{ count(); yylval.str = new std::string(yytext); return(CONSTANT); }
+{D}+"."{D}*({E})?{FS}?	{ count(); yylval.str = new std::string(yytext); return(CONSTANT); }
 
 L?\"(\\.|[^\\"])*\"	{ count(); return(STRING_LITERAL); }
 

--- a/src/c90_parser.y
+++ b/src/c90_parser.y
@@ -15,9 +15,10 @@
 }
 
 %union{
-	const Expression *expr;
-	double number;
+	Expression *expr;
+	long double number;
 	std::string *str;
+	ExpressionList *exprs;
 }
 
 %token IDENTIFIER CONSTANT STRING_LITERAL SIZEOF
@@ -32,19 +33,25 @@
 
 %token CASE DEFAULT IF ELSE SWITCH WHILE DO FOR GOTO CONTINUE BREAK RETURN
 
-%type <expr> translation_unit
-%type <expr> external_declaration function_definition declaration
-%type <str> primary_expression declarator direct_declarator postfix_expression
-%type <str> IDENTIFIER
+%type <expr> translation_unit expression statement compound_statement
+%type <exprs> statement_list
+%type <expr> external_declaration function_definition declaration jump_statement
+%type <expr> primary_expression declarator direct_declarator postfix_expression
+%type <str> IDENTIFIER CONSTANT
 
 %start translation_unit
 %%
 
 primary_expression
 	: IDENTIFIER {
-		$$ = new std::string(*$1);
+		$$ = new Identifier(std::string(*$1));
+		delete $1;
 	}
-	| CONSTANT
+	| CONSTANT {
+		std::cout << "Trying to parse constant: " << *$1 << std::endl;
+		$$ = new Number(std::stold(*$1));
+		delete $1;
+	}
 	| STRING_LITERAL
 	| '(' expression ')'
 	;
@@ -291,7 +298,10 @@ declarator
 	;
 
 direct_declarator
-	: IDENTIFIER { $$ = $1; }
+	: IDENTIFIER {
+		$$ = new Identifier(std::string(*$1));
+		delete $1;
+	}
 	| '(' declarator ')' { $$ = $2 ;}
 	| direct_declarator '[' constant_expression ']' { $$ = $1; }
 	| direct_declarator '[' ']' { $$ = $1; }
@@ -370,11 +380,11 @@ initializer_list
 
 statement
 	: labeled_statement
-	| compound_statement
+	| compound_statement { $$ = $1; }
 	| expression_statement
 	| selection_statement
 	| iteration_statement
-	| jump_statement
+	| jump_statement { $$ = $1; }
 	;
 
 labeled_statement
@@ -385,7 +395,7 @@ labeled_statement
 
 compound_statement
 	: '{' '}'
-	| '{' statement_list '}'
+	| '{' statement_list '}' { $$ = $2; }
 	| '{' declaration_list '}'
 	| '{' declaration_list statement_list '}'
 	;
@@ -396,8 +406,8 @@ declaration_list
 	;
 
 statement_list
-	: statement
-	| statement_list statement
+	: statement { $$ = new ExpressionList($1); }
+	| statement_list statement { $1->push_back($2); $$=$1; }
 	;
 
 expression_statement
@@ -422,8 +432,12 @@ jump_statement
 	: GOTO IDENTIFIER ';'
 	| CONTINUE ';'
 	| BREAK ';'
-	| RETURN ';'
-	| RETURN expression ';'
+	| RETURN ';' {
+		$$ = new Return();
+	}
+	| RETURN expression ';' {
+		$$ = new Return($2);
+	}
 	;
 
 translation_unit
@@ -452,9 +466,10 @@ function_definition
 	}
 	| declaration_specifiers declarator compound_statement {
 		// Normal functions
-		std::cout << "Got normal function: " << *$2 << std::endl;
 		std::vector<ExpressionPtr> args;
-		$$ = new Function(*$2, args);
+		auto funcName = dynamic_cast<const Identifier*>($2)->getId();
+		$$ = new Function(funcName, args, $3);
+		delete $2;
 	}
 	| declarator declaration_list compound_statement {
 		std::cerr << "Old K&R style function was parsed (2). This is not part of the tested specification." << std::endl;


### PR DESCRIPTION
Extends the `2024-cw-improvements` branch to be able to compile `int f() { return 5; }`