### PR TITLE
Improved compiler scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 *.output
 *.d
 *.gcno
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 bin/
+*.yy.cpp
+*.o
+*.tab.hpp
+*.tab.cpp
+*.output
+*.d

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 *.tab.cpp
 *.output
 *.d
+*.gcno

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y --fix-missing \
     build-essential \
     ca-certificates \
     curl \
-    device-tree-compiler
+    device-tree-compiler \
+    lcov
 
 # Install RISC-V Toolchain
 WORKDIR /tmp

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CPPFLAGS += -std=c++20 -W -Wall -g -I include
+CPPFLAGS += -std=c++20 -W -fsanitize=address -static-libasan -O0 -Wall -Wno-unused-parameter -g -I include
 
 .PHONY: default
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-CPPFLAGS += -std=c++20 -W -fsanitize=address -static-libasan -O0 -Wall -Wno-unused-parameter -g -I include
+# Based on https://stackoverflow.com/a/52036564 which is well worth reading!
+
+CXXFLAGS += -std=c++20 -W -fsanitize=address -static-libasan -O0 -Wall -Wno-unused-parameter -g -I include
+
+SOURCES := $(wildcard src/*.cpp)
+DEPENDENCIES := $(patsubst %.cpp,%.d,$(SOURCES))
+
+OBJECTS := $(patsubst %.cpp,%.o,$(SOURCES))
+OBJECTS += src/c90_parser.tab.o src/c90_lexer.yy.o
+
+CXX := g++
 
 .PHONY: default
 
@@ -10,9 +20,14 @@ src/c90_parser.tab.cpp src/c90_parser.tab.hpp : src/c90_parser.y
 src/c90_lexer.yy.cpp : src/c90_lexer.flex src/c90_parser.tab.hpp
 	flex -o src/c90_lexer.yy.cpp src/c90_lexer.flex
 
-bin/c_compiler : src/cli.cpp src/compiler.cpp src/c90_parser.tab.o src/c90_lexer.yy.o src/c90_parser.tab.o
+bin/c_compiler : $(OBJECTS)
 	@mkdir -p bin
-	g++ $(CPPFLAGS) -o bin/c_compiler $^
+	$(CXX) $(CXXFLAGS) -o $@ $^
+
+-include $(DEPENDENCIES)
+
+%.o: %.cpp Makefile
+	$(CXX) $(CXXFLAGS) -MMD -MP -c $< -o $@
 
 with_coverage : CPPFLAGS += --coverage
 with_coverage : bin/c_compiler
@@ -31,6 +46,7 @@ clean :
 	@rm -rf coverage
 	@find . -name "*.o" -delete
 	@rm -rf bin/*
+	@rm -rf $(OBJECTS) $(DEPENDENCIES)
 	@rm -f src/c90_parser.output
 	@rm -f src/c90_parser.tab.hpp
 	@rm -f src/c90_parser.tab.cpp

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ bin/c_compiler : $(OBJECTS)
 %.o: %.cpp Makefile
 	$(CXX) $(CXXFLAGS) -MMD -MP -c $< -o $@
 
-with_coverage : CPPFLAGS += --coverage
+with_coverage : CXXFLAGS += --coverage
 with_coverage : bin/c_compiler
 
 coverage : coverage/index.html

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,9 @@ clean :
 	@rm -rf coverage
 	@find . -name "*.o" -delete
 	@rm -rf bin/*
+	@rm -f src/c90_parser.output
+	@rm -f src/c90_parser.tab.hpp
+	@rm -f src/c90_parser.tab.cpp
+	@rm -f src/c90_parser.tab.o
+	@rm -f src/c90_lexer.yy.cpp
+	@rm -f src/c90_lexer.yy.o

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Based on https://stackoverflow.com/a/52036564 which is well worth reading!
 
-CXXFLAGS += -std=c++20 -W -fsanitize=address -static-libasan -O0 -Wall -Wno-unused-parameter -g -I include
+CXXFLAGS += -std=c++20 -W -fsanitize=address -static-libasan -O0 -Wall -Wno-unused-parameter -rdynamic -g -I include
 
 SOURCES := $(wildcard src/*.cpp)
 DEPENDENCIES := $(patsubst %.cpp,%.d,$(SOURCES))
@@ -51,5 +51,7 @@ clean :
 	@rm -f src/c90_parser.tab.hpp
 	@rm -f src/c90_parser.tab.cpp
 	@rm -f src/c90_parser.tab.o
+	@rm -f src/c90_parser.tab.gcno
 	@rm -f src/c90_lexer.yy.cpp
 	@rm -f src/c90_lexer.yy.o
+	@rm -f src/c90_lexer.yy.gcno

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,13 @@ CPPFLAGS += -std=c++20 -W -fsanitize=address -static-libasan -O0 -Wall -Wno-unus
 
 default: bin/c_compiler
 
-bin/c_compiler : src/cli.cpp src/compiler.cpp
+src/c90_parser.tab.cpp src/c90_parser.tab.hpp : src/c90_parser.y
+	bison -v -d src/c90_parser.y -o src/c90_parser.tab.cpp
+
+src/c90_lexer.yy.cpp : src/c90_lexer.flex src/c90_parser.tab.hpp
+	flex -o src/c90_lexer.yy.cpp src/c90_lexer.flex
+
+bin/c_compiler : src/cli.cpp src/compiler.cpp src/c90_parser.tab.o src/c90_lexer.yy.o src/c90_parser.tab.o
 	@mkdir -p bin
 	g++ $(CPPFLAGS) -o bin/c_compiler $^
 

--- a/docs/c_compiler.md
+++ b/docs/c_compiler.md
@@ -184,4 +184,4 @@ Useful links
 
 Getting started
 ---------------
-[How to get started? (previous students' perspetives)](./starting_guide.md)
+[How to get started? (previous students' perspectives)](./starting_guide.md)

--- a/docs/c_compiler.md
+++ b/docs/c_compiler.md
@@ -49,6 +49,8 @@ The compilation function is invoked using the flag `-S`, with the source file an
 
 You can assume that the command-line arguments will always be in this order, and that there will be no spaces in source or destination paths.
 
+NOTE: the provided starting point in this repository already functions as specified above.
+
 Input
 -----
 
@@ -180,6 +182,6 @@ Useful links
 
 * [RISC-V Assembler Reference](https://michaeljclark.github.io/asm.html) - Very useful resource containing information about structuring your output assembly files and most importantly the assembler directives - if you don't know the meaning behind `.data`, `.text`, or `.word` then definitely check this out as well as experiment with Godbolt to see how it actually emits them.
 
-Getting started 
+Getting started
 ---------------
 [How to get started? (previous students' perspetives)](./starting_guide.md)

--- a/docs/environment_guide.md
+++ b/docs/environment_guide.md
@@ -12,9 +12,14 @@ Many students develop their compiler in VS Code, as this has good support for co
 1) Install [Docker Desktop](https://www.docker.com/products/docker-desktop/). If you are on Apple M1/M2, make sure to choose the Apple Silicon download.
 2) Open VS Code and install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
 3) Open the folder containing this file, in VS Code
-4) Open the Command Palette in VS Code. You can do this by the shortcut `Ctrl + Shift + P` on Windows or `Cmd + Shift + P` on Mac. Alternatively, you can access this from `View -> Command Palette`.
+4) Open the Command Palette in VS Code:
+    - Windows: `Ctrl + Shift + P`
+    - Mac OS: `Cmd + Shift + P`
+    - Alternatively, you can access this from the menu bar `View -> Command Palette`.
 5) Enter `>Dev Containers: Reopen in Container` into the Command Palette
-6) After a delay -- depending on how fast your Internet connection can download ~1GB -- you will now be in the container environment. For those interested, VS Code reads the container configuration from the [.devcontainer/devcontainer.json](.devcontainer/devcontainer.json) file.
+6) After a delay you will now be in the container environment.
+    - The delay will vary based on how fast you can download around 1GB over your Internet connection.
+    - For those interested, VS Code reads the container configuration from the [.devcontainer/devcontainer.json](.devcontainer/devcontainer.json) file.
 7) Test that your tools are correctly setup by running `./toolchain_test.sh` in the VS Code terminal, accessible via `Terminal -> New Terminal`. Your output should look as follows:
 
     ```console
@@ -40,8 +45,15 @@ Many students develop their compiler in VS Code, as this has good support for co
 
 1) Install [Docker](https://www.docker.com/products/docker-desktop/). If you are on Apple M1/M2, make sure to choose the Apple Silicon download.
 2) Open a terminal (Powershell on Windows; Terminal on Mac) to the folder containing this file
-3) Inside that terminal, run `docker build -t compilers_image .`
-4) Once that completes, run `docker run --rm -it -v "${PWD}:/code" -w "/code" --name "compilers_env" compilers_image`
+3) Inside that terminal, run `docker build -t compilers_image .` to build the Docker container image
+4) Once that completes, run the following command to start the Docker container
+
+    ```
+    docker run --rm -it -v "${PWD}:/code" -w "/code" --name "compilers_env" compilers_image
+    ```
+
+6) You should now be inside the LangProc tools container, where you can run `./toolchain_test.sh` inside the `/code` folder to check that your tools are working correctly. Note that the folder containing this file, as well as any subdirectories, are mounted inside this container under the path `/code`. The output of running the command should look as follows:
+
 5) You should now be inside the LangProc tools container, where you can run `./toolchain_test.sh` inside the `/code` folder to check that your tools are working correctly. Note that the folder containing this file, as well as any subdirectories, are mounted inside this container under the path `/code`. The output of running the command should look as follows:
 
     ```console

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -1,0 +1,12 @@
+#ifndef ast_hpp
+#define ast_hpp
+
+#include "ast/ast_expression.hpp"
+#include "ast/ast_primitives.hpp"
+#include "ast/ast_operators.hpp"
+#include "ast/ast_unary.hpp"
+#include "ast/ast_functions.hpp"
+
+extern const Expression *parseAST();
+
+#endif

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -1,6 +1,7 @@
 #ifndef ast_hpp
 #define ast_hpp
 
+#include "ast/ast_context.hpp"
 #include "ast/ast_expression.hpp"
 #include "ast/ast_primitives.hpp"
 #include "ast/ast_operators.hpp"

--- a/include/ast/ast_context.hpp
+++ b/include/ast/ast_context.hpp
@@ -1,0 +1,17 @@
+#ifndef ast_context_hpp
+#define ast_context_hpp
+
+#include <string>
+#include <iostream>
+#include <map>
+#include <memory>
+
+class Context
+{
+public:
+    virtual ~Context()
+    {
+    }
+};
+
+#endif

--- a/include/ast/ast_expression.hpp
+++ b/include/ast/ast_expression.hpp
@@ -1,0 +1,32 @@
+#ifndef ast_expression_hpp
+#define ast_expression_hpp
+
+#include <string>
+#include <iostream>
+#include <map>
+
+#include <memory>
+
+class Expression;
+
+typedef const Expression *ExpressionPtr;
+
+class Expression
+{
+public:
+    virtual ~Expression()
+    {
+    }
+
+    //! Tell and expression to print itself to the given stream
+    virtual void print(std::ostream &dst) const = 0;
+
+    //! Evaluate the tree using the given mapping of variables to numbers
+    virtual double evaluate(
+        const std::map<std::string, double> &bindings) const
+    {
+        throw std::runtime_error("Not implemented.");
+    }
+};
+
+#endif

--- a/include/ast/ast_expression.hpp
+++ b/include/ast/ast_expression.hpp
@@ -19,7 +19,10 @@ public:
     }
 
     // Prints a text representation of the expression to dst.
-    virtual void print(std::ostream &dst) const = 0;
+    virtual void print(std::ostream &dst) const
+    {
+        throw std::runtime_error("print() not implemented.");
+    };
 
     // Compiles the expression, outputting assembly to dst.
     virtual void compile(Context &ctx, std::ostream &dst) const

--- a/include/ast/ast_expression.hpp
+++ b/include/ast/ast_expression.hpp
@@ -22,7 +22,7 @@ public:
     virtual void print(std::ostream &dst) const = 0;
 
     // Compiles the expression, outputting assembly to dst.
-    virtual void compile(std::ostream &dst) const
+    virtual void compile(Context &ctx, std::ostream &dst) const
     {
         throw std::runtime_error("Not implemented.");
     }

--- a/include/ast/ast_expression.hpp
+++ b/include/ast/ast_expression.hpp
@@ -18,12 +18,11 @@ public:
     {
     }
 
-    //! Tell and expression to print itself to the given stream
+    // Prints a text representation of the expression to dst.
     virtual void print(std::ostream &dst) const = 0;
 
-    //! Evaluate the tree using the given mapping of variables to numbers
-    virtual double evaluate(
-        const std::map<std::string, double> &bindings) const
+    // Compiles the expression, outputting assembly to dst.
+    virtual void compile(std::ostream &dst) const
     {
         throw std::runtime_error("Not implemented.");
     }

--- a/include/ast/ast_expression.hpp
+++ b/include/ast/ast_expression.hpp
@@ -2,10 +2,7 @@
 #define ast_expression_hpp
 
 #include <string>
-#include <iostream>
-#include <map>
-
-#include <memory>
+#include <vector>
 
 class Expression;
 
@@ -28,6 +25,57 @@ public:
     virtual void compile(Context &ctx, std::ostream &dst) const
     {
         throw std::runtime_error("Not implemented.");
+    }
+};
+
+// Represents a list/vector of expressions.
+class ExpressionList
+    : public Expression
+{
+private:
+    std::vector<ExpressionPtr> exprs;
+
+public:
+    ExpressionList(ExpressionPtr firstItem)
+        : exprs({firstItem})
+    {
+    }
+
+    ~ExpressionList()
+    {
+        for (auto expr : exprs)
+        {
+            delete expr;
+        }
+    }
+
+    inline void push_back(ExpressionPtr item)
+    {
+        exprs.push_back(item);
+    }
+
+    virtual void print(std::ostream &dst) const override
+    {
+        for (auto expr : exprs)
+        {
+            if (expr == nullptr)
+            {
+                continue;
+            }
+            expr->print(dst);
+        }
+    }
+
+    virtual void compile(Context &ctx, std::ostream &dst) const override
+    {
+        for (auto expr : exprs)
+        {
+            if (expr == nullptr)
+            {
+                continue;
+            }
+            expr->compile(ctx, dst);
+        }
     }
 };
 

--- a/include/ast/ast_functions.hpp
+++ b/include/ast/ast_functions.hpp
@@ -1,0 +1,64 @@
+#ifndef ast_functions_hpp
+#define ast_functions_hpp
+
+#include "ast_expression.hpp"
+
+#include <cmath>
+#include <vector>
+
+class Function
+    : public Expression
+{
+private:
+    std::string name;
+    std::vector<ExpressionPtr> args;
+    ExpressionPtr body;
+
+public:
+    Function(std::string _name, std::vector<ExpressionPtr> _args)
+        : name(_name), args(_args), body(nullptr)
+    {
+    }
+
+    virtual ~Function()
+    {
+        // delete args;
+    }
+
+    std::string getName() const
+    {
+        return name;
+    }
+
+    std::vector<ExpressionPtr> getArgs() const
+    {
+        return args;
+    }
+
+    virtual void print(std::ostream &dst) const override
+    {
+        dst << name << "( ";
+        for (auto &&arg : args)
+        {
+            arg->print(dst);
+        }
+        dst << " )";
+
+        dst << "{" << std::endl;
+        if (body != nullptr)
+        {
+            body->print(dst);
+            dst << std::endl;
+        }
+        dst << "}" << std::endl;
+    }
+
+    virtual double evaluate(
+        const std::map<std::string, double> &bindings) const override
+    {
+        // NOTE : This should be implemented by the inheriting function nodes, e.g. LogFunction
+        throw std::runtime_error("FunctionOperator::evaluate is not implemented.");
+    }
+};
+
+#endif

--- a/include/ast/ast_functions.hpp
+++ b/include/ast/ast_functions.hpp
@@ -15,17 +15,22 @@ private:
     ExpressionPtr body;
 
 public:
-    Function(std::string _name, std::vector<ExpressionPtr> _args)
-        : name(_name), args(_args), body(nullptr)
+    Function(std::string _name, std::vector<ExpressionPtr> _args, Expression *_body)
+        : name(_name), args(_args), body(_body)
     {
     }
 
     virtual ~Function()
     {
-        // delete args;
+        for (auto expr : args)
+        {
+            delete expr;
+        }
+        delete body;
     }
 
-    std::string getName() const
+    std::string
+    getName() const
     {
         return name;
     }
@@ -37,12 +42,12 @@ public:
 
     virtual void print(std::ostream &dst) const override
     {
-        dst << name << "( ";
+        dst << name << "(";
         for (auto &&arg : args)
         {
             arg->print(dst);
         }
-        dst << " )";
+        dst << ")";
 
         dst << "{" << std::endl;
         if (body != nullptr)

--- a/include/ast/ast_functions.hpp
+++ b/include/ast/ast_functions.hpp
@@ -53,7 +53,7 @@ public:
         dst << "}" << std::endl;
     }
 
-    virtual void compile(std::ostream &dst) const override
+    virtual void compile(Context &ctx, std::ostream &dst) const override
     {
         throw std::runtime_error("Function: compile is not implemented.");
     }

--- a/include/ast/ast_functions.hpp
+++ b/include/ast/ast_functions.hpp
@@ -53,11 +53,9 @@ public:
         dst << "}" << std::endl;
     }
 
-    virtual double evaluate(
-        const std::map<std::string, double> &bindings) const override
+    virtual void compile(std::ostream &dst) const override
     {
-        // NOTE : This should be implemented by the inheriting function nodes, e.g. LogFunction
-        throw std::runtime_error("FunctionOperator::evaluate is not implemented.");
+        throw std::runtime_error("Function: compile is not implemented.");
     }
 };
 

--- a/include/ast/ast_functions.hpp
+++ b/include/ast/ast_functions.hpp
@@ -60,7 +60,7 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        throw std::runtime_error("Function: compile is not implemented.");
+        std::cerr << "Function: compile is not implemented." << std::endl;
     }
 };
 

--- a/include/ast/ast_operators.hpp
+++ b/include/ast/ast_operators.hpp
@@ -65,7 +65,7 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        throw std::runtime_error("AddOperator: compile is not implemented");
+        std::cerr << "AddOperator: compile is not implemented" << std::endl;
     }
 };
 
@@ -86,7 +86,7 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        throw std::runtime_error("SubOperator: compile is not implemented");
+        std::cerr << "SubOperator: compile is not implemented" << std::endl;
     }
 };
 
@@ -107,7 +107,7 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        throw std::runtime_error("MulOperator: compile is not implemented");
+        std::cerr << "MulOperator: compile is not implemented" << std::endl;
     }
 };
 
@@ -128,7 +128,7 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        throw std::runtime_error("DivOperator: compile is not implemented");
+        std::cerr << "DivOperator: compile is not implemented" << std::endl;
     }
 };
 
@@ -149,7 +149,7 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        throw std::runtime_error("ExpOperator: compile is not implemented");
+        std::cerr << "ExpOperator: compile is not implemented" << std::endl;
     }
 };
 

--- a/include/ast/ast_operators.hpp
+++ b/include/ast/ast_operators.hpp
@@ -63,7 +63,7 @@ public:
     {
     }
 
-    virtual void compile(std::ostream &dst) const override
+    virtual void compile(Context &ctx, std::ostream &dst) const override
     {
         throw std::runtime_error("AddOperator: compile is not implemented");
     }
@@ -84,7 +84,7 @@ public:
     {
     }
 
-    virtual void compile(std::ostream &dst) const override
+    virtual void compile(Context &ctx, std::ostream &dst) const override
     {
         throw std::runtime_error("SubOperator: compile is not implemented");
     }
@@ -105,7 +105,7 @@ public:
     {
     }
 
-    virtual void compile(std::ostream &dst) const override
+    virtual void compile(Context &ctx, std::ostream &dst) const override
     {
         throw std::runtime_error("MulOperator: compile is not implemented");
     }
@@ -126,7 +126,7 @@ public:
     {
     }
 
-    virtual void compile(std::ostream &dst) const override
+    virtual void compile(Context &ctx, std::ostream &dst) const override
     {
         throw std::runtime_error("DivOperator: compile is not implemented");
     }
@@ -147,7 +147,7 @@ public:
     {
     }
 
-    virtual void compile(std::ostream &dst) const override
+    virtual void compile(Context &ctx, std::ostream &dst) const override
     {
         throw std::runtime_error("ExpOperator: compile is not implemented");
     }

--- a/include/ast/ast_operators.hpp
+++ b/include/ast/ast_operators.hpp
@@ -1,0 +1,165 @@
+#ifndef ast_operators_hpp
+#define ast_operators_hpp
+
+#include <string>
+#include <iostream>
+
+class Operator
+    : public Expression
+{
+private:
+    ExpressionPtr left;
+    ExpressionPtr right;
+
+protected:
+    Operator(ExpressionPtr _left, ExpressionPtr _right)
+        : left(_left), right(_right)
+    {
+    }
+
+public:
+    virtual ~Operator()
+    {
+        delete left;
+        delete right;
+    }
+
+    virtual const char *getOpcode() const = 0;
+
+    ExpressionPtr getLeft() const
+    {
+        return left;
+    }
+
+    ExpressionPtr getRight() const
+    {
+        return right;
+    }
+
+    virtual void print(std::ostream &dst) const override
+    {
+        dst << "( ";
+        left->print(dst);
+        dst << " ";
+        dst << getOpcode();
+        dst << " ";
+        right->print(dst);
+        dst << " )";
+    }
+};
+
+class AddOperator
+    : public Operator
+{
+protected:
+    virtual const char *getOpcode() const override
+    {
+        return "+";
+    }
+
+public:
+    AddOperator(ExpressionPtr _left, ExpressionPtr _right)
+        : Operator(_left, _right)
+    {
+    }
+
+    virtual double evaluate(
+        const std::map<std::string, double> &bindings) const override
+    {
+        // TODO-C : Run bin/eval_expr with something like 5+a, where a=10, to make sure you understand how this works
+        double vl = getLeft()->evaluate(bindings);
+        double vr = getRight()->evaluate(bindings);
+        return vl + vr;
+    }
+};
+
+class SubOperator
+    : public Operator
+{
+protected:
+    virtual const char *getOpcode() const override
+    {
+        return "-";
+    }
+
+public:
+    SubOperator(ExpressionPtr _left, ExpressionPtr _right)
+        : Operator(_left, _right)
+    {
+    }
+
+    virtual double evaluate(
+        const std::map<std::string, double> &bindings) const override
+    {
+        // TODO-D : Implement this, based on AddOperator::evaluate
+        throw std::runtime_error("MulOperator::evaluate is not implemented.");
+    }
+};
+
+class MulOperator
+    : public Operator
+{
+protected:
+    virtual const char *getOpcode() const override
+    {
+        return "*";
+    }
+
+public:
+    MulOperator(ExpressionPtr _left, ExpressionPtr _right)
+        : Operator(_left, _right)
+    {
+    }
+
+    virtual double evaluate(
+        const std::map<std::string, double> &bindings) const override
+    {
+        throw std::runtime_error("MulOperator::evaluate is not implemented.");
+    }
+};
+
+class DivOperator
+    : public Operator
+{
+protected:
+    virtual const char *getOpcode() const override
+    {
+        return "/";
+    }
+
+public:
+    DivOperator(ExpressionPtr _left, ExpressionPtr _right)
+        : Operator(_left, _right)
+    {
+    }
+
+    virtual double evaluate(
+        const std::map<std::string, double> &bindings) const override
+    {
+        throw std::runtime_error("DivOperator::evaluate is not implemented.");
+    }
+};
+
+class ExpOperator
+    : public Operator
+{
+protected:
+    virtual const char *getOpcode() const override
+    {
+        return "^";
+    }
+
+public:
+    ExpOperator(ExpressionPtr _left, ExpressionPtr _right)
+        : Operator(_left, _right)
+    {
+    }
+
+    virtual double evaluate(
+        const std::map<std::string, double> &bindings) const override
+    {
+        throw std::runtime_error("ExpOperator::evaluate is not implemented.");
+    }
+};
+
+#endif

--- a/include/ast/ast_operators.hpp
+++ b/include/ast/ast_operators.hpp
@@ -63,13 +63,9 @@ public:
     {
     }
 
-    virtual double evaluate(
-        const std::map<std::string, double> &bindings) const override
+    virtual void compile(std::ostream &dst) const override
     {
-        // TODO-C : Run bin/eval_expr with something like 5+a, where a=10, to make sure you understand how this works
-        double vl = getLeft()->evaluate(bindings);
-        double vr = getRight()->evaluate(bindings);
-        return vl + vr;
+        throw std::runtime_error("AddOperator: compile is not implemented");
     }
 };
 
@@ -88,11 +84,9 @@ public:
     {
     }
 
-    virtual double evaluate(
-        const std::map<std::string, double> &bindings) const override
+    virtual void compile(std::ostream &dst) const override
     {
-        // TODO-D : Implement this, based on AddOperator::evaluate
-        throw std::runtime_error("MulOperator::evaluate is not implemented.");
+        throw std::runtime_error("SubOperator: compile is not implemented");
     }
 };
 
@@ -111,10 +105,9 @@ public:
     {
     }
 
-    virtual double evaluate(
-        const std::map<std::string, double> &bindings) const override
+    virtual void compile(std::ostream &dst) const override
     {
-        throw std::runtime_error("MulOperator::evaluate is not implemented.");
+        throw std::runtime_error("MulOperator: compile is not implemented");
     }
 };
 
@@ -133,10 +126,9 @@ public:
     {
     }
 
-    virtual double evaluate(
-        const std::map<std::string, double> &bindings) const override
+    virtual void compile(std::ostream &dst) const override
     {
-        throw std::runtime_error("DivOperator::evaluate is not implemented.");
+        throw std::runtime_error("DivOperator: compile is not implemented");
     }
 };
 
@@ -155,10 +147,9 @@ public:
     {
     }
 
-    virtual double evaluate(
-        const std::map<std::string, double> &bindings) const override
+    virtual void compile(std::ostream &dst) const override
     {
-        throw std::runtime_error("ExpOperator::evaluate is not implemented.");
+        throw std::runtime_error("ExpOperator: compile is not implemented");
     }
 };
 

--- a/include/ast/ast_primitives.hpp
+++ b/include/ast/ast_primitives.hpp
@@ -26,7 +26,7 @@ public:
         dst << id;
     }
 
-    virtual void compile(std::ostream &dst) const override
+    virtual void compile(Context &ctx, std::ostream &dst) const override
     {
         throw std::runtime_error("Variable: compile is not implemented");
     }
@@ -54,7 +54,7 @@ public:
         dst << value;
     }
 
-    virtual void compile(std::ostream &dst) const override
+    virtual void compile(Context &ctx, std::ostream &dst) const override
     {
         throw std::runtime_error("Number: compile is not implemented");
     }

--- a/include/ast/ast_primitives.hpp
+++ b/include/ast/ast_primitives.hpp
@@ -26,12 +26,9 @@ public:
         dst << id;
     }
 
-    virtual double evaluate(
-        const std::map<std::string, double> &bindings) const override
+    virtual void compile(std::ostream &dst) const override
     {
-        // TODO-B : Run bin/eval_expr with a variable binding to make sure you understand how this works.
-        // If the binding does not exist, this will throw an error
-        return bindings.at(id);
+        throw std::runtime_error("Variable: compile is not implemented");
     }
 };
 
@@ -57,11 +54,9 @@ public:
         dst << value;
     }
 
-    virtual double evaluate(
-        const std::map<std::string, double> &bindings) const override
+    virtual void compile(std::ostream &dst) const override
     {
-        // TODO-A : Run bin/eval_expr with a numeric expression to make sure you understand how this works.
-        return value;
+        throw std::runtime_error("Number: compile is not implemented");
     }
 };
 

--- a/include/ast/ast_primitives.hpp
+++ b/include/ast/ast_primitives.hpp
@@ -28,7 +28,7 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        throw std::runtime_error("Variable: compile is not implemented");
+        std::cerr << "Variable: compile is not implemented" << std::endl;
     }
 };
 
@@ -56,7 +56,7 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        throw std::runtime_error("Number: compile is not implemented");
+        std::cerr << "Number: compile is not implemented" << std::endl;
     }
 };
 

--- a/include/ast/ast_primitives.hpp
+++ b/include/ast/ast_primitives.hpp
@@ -1,0 +1,68 @@
+#ifndef ast_primitives_hpp
+#define ast_primitives_hpp
+
+#include <string>
+#include <iostream>
+
+class Variable
+    : public Expression
+{
+private:
+    std::string id;
+
+public:
+    Variable(const std::string &_id)
+        : id(_id)
+    {
+    }
+
+    const std::string getId() const
+    {
+        return id;
+    }
+
+    virtual void print(std::ostream &dst) const override
+    {
+        dst << id;
+    }
+
+    virtual double evaluate(
+        const std::map<std::string, double> &bindings) const override
+    {
+        // TODO-B : Run bin/eval_expr with a variable binding to make sure you understand how this works.
+        // If the binding does not exist, this will throw an error
+        return bindings.at(id);
+    }
+};
+
+class Number
+    : public Expression
+{
+private:
+    double value;
+
+public:
+    Number(double _value)
+        : value(_value)
+    {
+    }
+
+    double getValue() const
+    {
+        return value;
+    }
+
+    virtual void print(std::ostream &dst) const override
+    {
+        dst << value;
+    }
+
+    virtual double evaluate(
+        const std::map<std::string, double> &bindings) const override
+    {
+        // TODO-A : Run bin/eval_expr with a numeric expression to make sure you understand how this works.
+        return value;
+    }
+};
+
+#endif

--- a/include/ast/ast_unary.hpp
+++ b/include/ast/ast_unary.hpp
@@ -1,0 +1,64 @@
+#ifndef ast_unary_hpp
+#define ast_unary_hpp
+
+#include <string>
+#include <iostream>
+
+class Unary
+    : public Expression
+{
+private:
+    ExpressionPtr expr;
+
+protected:
+    Unary(const ExpressionPtr _expr)
+        : expr(_expr)
+    {
+    }
+
+public:
+    virtual ~Unary()
+    {
+        delete expr;
+    }
+
+    virtual const char *getOpcode() const = 0;
+
+    ExpressionPtr getExpr() const
+    {
+        return expr;
+    }
+
+    virtual void print(std::ostream &dst) const override
+    {
+        dst << "( ";
+        dst << getOpcode();
+        dst << " ";
+        expr->print(dst);
+        dst << " )";
+    }
+};
+
+class NegOperator
+    : public Unary
+{
+public:
+    NegOperator(const ExpressionPtr _expr)
+        : Unary(_expr)
+    {
+    }
+
+    virtual const char *getOpcode() const override
+    {
+        return "-";
+    }
+
+    virtual double evaluate(
+        const std::map<std::string, double> &bindings) const override
+    {
+        // TODO-F: Implement this similar to how AddOperator was implemented.
+        throw std::runtime_error("NegOperator::evaluate is not implemented.");
+    }
+};
+
+#endif

--- a/include/ast/ast_unary.hpp
+++ b/include/ast/ast_unary.hpp
@@ -53,11 +53,9 @@ public:
         return "-";
     }
 
-    virtual double evaluate(
-        const std::map<std::string, double> &bindings) const override
+    virtual void compile(std::ostream &dst) const override
     {
-        // TODO-F: Implement this similar to how AddOperator was implemented.
-        throw std::runtime_error("NegOperator::evaluate is not implemented.");
+        throw std::runtime_error("NegOperator: compile is not implemented");
     }
 };
 

--- a/include/ast/ast_unary.hpp
+++ b/include/ast/ast_unary.hpp
@@ -53,7 +53,7 @@ public:
         return "-";
     }
 
-    virtual void compile(std::ostream &dst) const override
+    virtual void compile(Context &ctx, std::ostream &dst) const override
     {
         throw std::runtime_error("NegOperator: compile is not implemented");
     }

--- a/include/ast/ast_unary.hpp
+++ b/include/ast/ast_unary.hpp
@@ -55,7 +55,7 @@ public:
 
     virtual void compile(Context &ctx, std::ostream &dst) const override
     {
-        throw std::runtime_error("NegOperator: compile is not implemented");
+        std::cerr << "NegOperator: compile is not implemented" << std::endl;
     }
 };
 

--- a/include/cli.h
+++ b/include/cli.h
@@ -2,8 +2,18 @@
 #define LANGPROC_COMPILER_CLI_H
 
 #include <iostream>
+#include <stdio.h>
+#include <execinfo.h>
+#include <signal.h>
+#include <stdlib.h>
 #include <unistd.h>
 
-int parse_command_line_args(int argc, char **argv, std::string &sourcePath, std::string &outputPath);
+struct CommandLineArguments
+{
+    std::string compileSourcePath;
+    std::string compileOutputPath;
+};
+
+CommandLineArguments parse_command_line_args(int argc, char **argv);
 
 #endif

--- a/src/c90_lexer.flex
+++ b/src/c90_lexer.flex
@@ -1,4 +1,4 @@
-// Source: https://www.lysator.liu.se/c/ANSI-C-grammar-l.html
+/* Source: https://www.lysator.liu.se/c/ANSI-C-grammar-l.html */
 
 D			[0-9]
 L			[a-zA-Z_]

--- a/src/c90_lexer.flex
+++ b/src/c90_lexer.flex
@@ -1,0 +1,186 @@
+// Source: https://www.lysator.liu.se/c/ANSI-C-grammar-l.html
+
+D			[0-9]
+L			[a-zA-Z_]
+H			[a-fA-F0-9]
+E			[Ee][+-]?{D}+
+FS			(f|F|l|L)
+IS			(u|U|l|L)*
+
+%{
+#include <stdio.h>
+#include "c90_parser.tab.hpp"
+
+// Avoids error "error: `fileno' was not declared in this scope"
+extern "C" int fileno(FILE *stream);
+
+void count();
+void comment();
+int check_type();
+%}
+
+%%
+
+"/*"			{ comment(); }
+
+"auto"			{ count(); return(AUTO); }
+"break"			{ count(); return(BREAK); }
+"case"			{ count(); return(CASE); }
+"char"			{ count(); return(CHAR); }
+"const"			{ count(); return(CONST); }
+"continue"		{ count(); return(CONTINUE); }
+"default"		{ count(); return(DEFAULT); }
+"do"			{ count(); return(DO); }
+"double"		{ count(); return(DOUBLE); }
+"else"			{ count(); return(ELSE); }
+"enum"			{ count(); return(ENUM); }
+"extern"		{ count(); return(EXTERN); }
+"float"			{ count(); return(FLOAT); }
+"for"			{ count(); return(FOR); }
+"goto"			{ count(); return(GOTO); }
+"if"			{ count(); return(IF); }
+"int"			{ count(); return(INT); }
+"long"			{ count(); return(LONG); }
+"register"		{ count(); return(REGISTER); }
+"return"		{ count(); return(RETURN); }
+"short"			{ count(); return(SHORT); }
+"signed"		{ count(); return(SIGNED); }
+"sizeof"		{ count(); return(SIZEOF); }
+"static"		{ count(); return(STATIC); }
+"struct"		{ count(); return(STRUCT); }
+"switch"		{ count(); return(SWITCH); }
+"typedef"		{ count(); return(TYPEDEF); }
+"union"			{ count(); return(UNION); }
+"unsigned"		{ count(); return(UNSIGNED); }
+"void"			{ count(); return(VOID); }
+"volatile"		{ count(); return(VOLATILE); }
+"while"			{ count(); return(WHILE); }
+
+{L}({L}|{D})* {
+    count();
+    yylval.str = new std::string(yytext);
+    return check_type();
+}
+
+0[xX]{H}+{IS}?		{ count(); return(CONSTANT); }
+0{D}+{IS}?		    { count(); return(CONSTANT); }
+{D}+{IS}?		    { count(); return(CONSTANT); }
+L?'(\\.|[^\\'])+'	{ count(); return(CONSTANT); }
+
+{D}+{E}{FS}?		    { count(); return(CONSTANT); }
+{D}*"."{D}+({E})?{FS}?	{ count(); return(CONSTANT); }
+{D}+"."{D}*({E})?{FS}?	{ count(); return(CONSTANT); }
+
+L?\"(\\.|[^\\"])*\"	{ count(); return(STRING_LITERAL); }
+
+"..."			{ count(); return(ELLIPSIS); }
+">>="			{ count(); return(RIGHT_ASSIGN); }
+"<<="			{ count(); return(LEFT_ASSIGN); }
+"+="			{ count(); return(ADD_ASSIGN); }
+"-="			{ count(); return(SUB_ASSIGN); }
+"*="			{ count(); return(MUL_ASSIGN); }
+"/="			{ count(); return(DIV_ASSIGN); }
+"%="			{ count(); return(MOD_ASSIGN); }
+"&="			{ count(); return(AND_ASSIGN); }
+"^="			{ count(); return(XOR_ASSIGN); }
+"|="			{ count(); return(OR_ASSIGN); }
+">>"			{ count(); return(RIGHT_OP); }
+"<<"			{ count(); return(LEFT_OP); }
+"++"			{ count(); return(INC_OP); }
+"--"			{ count(); return(DEC_OP); }
+"->"			{ count(); return(PTR_OP); }
+"&&"			{ count(); return(AND_OP); }
+"||"			{ count(); return(OR_OP); }
+"<="			{ count(); return(LE_OP); }
+">="			{ count(); return(GE_OP); }
+"=="			{ count(); return(EQ_OP); }
+"!="			{ count(); return(NE_OP); }
+";"			    { count(); return(';'); }
+("{"|"<%")		{ count(); return('{'); }
+("}"|"%>")		{ count(); return('}'); }
+","			    { count(); return(','); }
+":"			    { count(); return(':'); }
+"="			    { count(); return('='); }
+"("			    { count(); return('('); }
+")"			    { count(); return(')'); }
+("["|"<:")		{ count(); return('['); }
+("]"|":>")		{ count(); return(']'); }
+"."			    { count(); return('.'); }
+"&"			    { count(); return('&'); }
+"!"			    { count(); return('!'); }
+"~"			    { count(); return('~'); }
+"-"			    { count(); return('-'); }
+"+"			    { count(); return('+'); }
+"*"			    { count(); return('*'); }
+"/"			    { count(); return('/'); }
+"%"			    { count(); return('%'); }
+"<"			    { count(); return('<'); }
+">"			    { count(); return('>'); }
+"^"			    { count(); return('^'); }
+"|"			    { count(); return('|'); }
+"?"			    { count(); return('?'); }
+
+[ \t\v\n\f]		{ count(); }
+.			    { /* ignore bad characters */ }
+
+%%
+
+int yywrap()
+{
+    return (1);
+}
+
+void comment()
+{
+    char c, c1;
+
+loop:
+    while ((c = yyinput()) != '*' && c != 0) {}
+
+    if ((c1 = yyinput()) != '/' && c != 0)
+    {
+        unput(c1);
+        goto loop;
+    }
+}
+
+int column = 0;
+
+void count()
+{
+    int i;
+
+    for (i = 0; yytext[i] != '\0'; i++)
+        if (yytext[i] == '\n')
+            column = 0;
+        else if (yytext[i] == '\t')
+            column += 8 - (column % 8);
+        else
+            column++;
+
+    ECHO;
+}
+
+int check_type()
+{
+    /*
+     * pseudo code --- this is what it should check
+     *
+     *	if (yytext == type_name)
+     *		return(TYPE_NAME);
+     *
+     *	return(IDENTIFIER);
+     */
+
+    /*
+     *	it actually will only return IDENTIFIER
+     */
+
+    return IDENTIFIER;
+}
+
+void yyerror (char const *s)
+{
+  fprintf (stderr, "Parse error : %s\n", s);
+  exit(1);
+}

--- a/src/c90_parser.y
+++ b/src/c90_parser.y
@@ -1,0 +1,484 @@
+// Source: https://www.lysator.liu.se/c/ANSI-C-grammar-y.html
+
+%code requires{
+  #include "ast.hpp"
+
+  #include <cassert>
+
+  extern const Expression *g_root; // A way of getting the AST out
+
+  //! This is to fix problems when generating C++
+  // We are declaring the functions provided by Flex, so
+  // that Bison generated code can call them.
+  int yylex(void);
+  void yyerror(const char *);
+}
+
+%union{
+	const Expression *expr;
+	double number;
+	std::string *str;
+}
+
+%token IDENTIFIER CONSTANT STRING_LITERAL SIZEOF
+%token PTR_OP INC_OP DEC_OP LEFT_OP RIGHT_OP LE_OP GE_OP EQ_OP NE_OP
+%token AND_OP OR_OP MUL_ASSIGN DIV_ASSIGN MOD_ASSIGN ADD_ASSIGN
+%token SUB_ASSIGN LEFT_ASSIGN RIGHT_ASSIGN AND_ASSIGN
+%token XOR_ASSIGN OR_ASSIGN TYPE_NAME
+
+%token TYPEDEF EXTERN STATIC AUTO REGISTER
+%token CHAR SHORT INT LONG SIGNED UNSIGNED FLOAT DOUBLE CONST VOLATILE VOID
+%token STRUCT UNION ENUM ELLIPSIS
+
+%token CASE DEFAULT IF ELSE SWITCH WHILE DO FOR GOTO CONTINUE BREAK RETURN
+
+%type <expr> translation_unit
+%type <expr> external_declaration function_definition declaration
+%type <str> primary_expression declarator direct_declarator postfix_expression
+%type <str> IDENTIFIER
+
+%start translation_unit
+%%
+
+primary_expression
+	: IDENTIFIER {
+		$$ = new std::string(*$1);
+	}
+	| CONSTANT
+	| STRING_LITERAL
+	| '(' expression ')'
+	;
+
+postfix_expression
+	: primary_expression { $$ = $1; }
+	| postfix_expression '[' expression ']'
+	| postfix_expression '(' ')'
+	| postfix_expression '(' argument_expression_list ')'
+	| postfix_expression '.' IDENTIFIER
+	| postfix_expression PTR_OP IDENTIFIER
+	| postfix_expression INC_OP
+	| postfix_expression DEC_OP
+	;
+
+argument_expression_list
+	: assignment_expression
+	| argument_expression_list ',' assignment_expression
+	;
+
+unary_expression
+	: postfix_expression
+	| INC_OP unary_expression
+	| DEC_OP unary_expression
+	| unary_operator cast_expression
+	| SIZEOF unary_expression
+	| SIZEOF '(' type_name ')'
+	;
+
+unary_operator
+	: '&'
+	| '*'
+	| '+'
+	| '-'
+	| '~'
+	| '!'
+	;
+
+cast_expression
+	: unary_expression
+	| '(' type_name ')' cast_expression
+	;
+
+multiplicative_expression
+	: cast_expression
+	| multiplicative_expression '*' cast_expression
+	| multiplicative_expression '/' cast_expression
+	| multiplicative_expression '%' cast_expression
+	;
+
+additive_expression
+	: multiplicative_expression
+	| additive_expression '+' multiplicative_expression
+	| additive_expression '-' multiplicative_expression
+	;
+
+shift_expression
+	: additive_expression
+	| shift_expression LEFT_OP additive_expression
+	| shift_expression RIGHT_OP additive_expression
+	;
+
+relational_expression
+	: shift_expression
+	| relational_expression '<' shift_expression
+	| relational_expression '>' shift_expression
+	| relational_expression LE_OP shift_expression
+	| relational_expression GE_OP shift_expression
+	;
+
+equality_expression
+	: relational_expression
+	| equality_expression EQ_OP relational_expression
+	| equality_expression NE_OP relational_expression
+	;
+
+and_expression
+	: equality_expression
+	| and_expression '&' equality_expression
+	;
+
+exclusive_or_expression
+	: and_expression
+	| exclusive_or_expression '^' and_expression
+	;
+
+inclusive_or_expression
+	: exclusive_or_expression
+	| inclusive_or_expression '|' exclusive_or_expression
+	;
+
+logical_and_expression
+	: inclusive_or_expression
+	| logical_and_expression AND_OP inclusive_or_expression
+	;
+
+logical_or_expression
+	: logical_and_expression
+	| logical_or_expression OR_OP logical_and_expression
+	;
+
+conditional_expression
+	: logical_or_expression
+	| logical_or_expression '?' expression ':' conditional_expression
+	;
+
+assignment_expression
+	: conditional_expression
+	| unary_expression assignment_operator assignment_expression
+	;
+
+assignment_operator
+	: '='
+	| MUL_ASSIGN
+	| DIV_ASSIGN
+	| MOD_ASSIGN
+	| ADD_ASSIGN
+	| SUB_ASSIGN
+	| LEFT_ASSIGN
+	| RIGHT_ASSIGN
+	| AND_ASSIGN
+	| XOR_ASSIGN
+	| OR_ASSIGN
+	;
+
+expression
+	: assignment_expression
+	| expression ',' assignment_expression
+	;
+
+constant_expression
+	: conditional_expression
+	;
+
+declaration
+	: declaration_specifiers ';'
+	| declaration_specifiers init_declarator_list ';'
+	;
+
+declaration_specifiers
+	: storage_class_specifier
+	| storage_class_specifier declaration_specifiers
+	| type_specifier
+	| type_specifier declaration_specifiers
+	| type_qualifier
+	| type_qualifier declaration_specifiers
+	;
+
+init_declarator_list
+	: init_declarator
+	| init_declarator_list ',' init_declarator
+	;
+
+init_declarator
+	: declarator
+	| declarator '=' initializer
+	;
+
+storage_class_specifier
+	: TYPEDEF
+	| EXTERN
+	| STATIC
+	| AUTO
+	| REGISTER
+	;
+
+type_specifier
+	: VOID
+	| CHAR
+	| SHORT
+	| INT
+	| LONG
+	| FLOAT
+	| DOUBLE
+	| SIGNED
+	| UNSIGNED
+	| struct_or_union_specifier
+	| enum_specifier
+	| TYPE_NAME
+	;
+
+struct_or_union_specifier
+	: struct_or_union IDENTIFIER '{' struct_declaration_list '}'
+	| struct_or_union '{' struct_declaration_list '}'
+	| struct_or_union IDENTIFIER
+	;
+
+struct_or_union
+	: STRUCT
+	| UNION
+	;
+
+struct_declaration_list
+	: struct_declaration
+	| struct_declaration_list struct_declaration
+	;
+
+struct_declaration
+	: specifier_qualifier_list struct_declarator_list ';'
+	;
+
+specifier_qualifier_list
+	: type_specifier specifier_qualifier_list
+	| type_specifier
+	| type_qualifier specifier_qualifier_list
+	| type_qualifier
+	;
+
+struct_declarator_list
+	: struct_declarator
+	| struct_declarator_list ',' struct_declarator
+	;
+
+struct_declarator
+	: declarator
+	| ':' constant_expression
+	| declarator ':' constant_expression
+	;
+
+enum_specifier
+	: ENUM '{' enumerator_list '}'
+	| ENUM IDENTIFIER '{' enumerator_list '}'
+	| ENUM IDENTIFIER
+	;
+
+enumerator_list
+	: enumerator
+	| enumerator_list ',' enumerator
+	;
+
+enumerator
+	: IDENTIFIER
+	| IDENTIFIER '=' constant_expression
+	;
+
+type_qualifier
+	: CONST
+	| VOLATILE
+	;
+
+declarator
+	: pointer direct_declarator
+	| direct_declarator { $$ = $1; }
+	;
+
+direct_declarator
+	: IDENTIFIER { $$ = $1; }
+	| '(' declarator ')' { $$ = $2 ;}
+	| direct_declarator '[' constant_expression ']' { $$ = $1; }
+	| direct_declarator '[' ']' { $$ = $1; }
+	| direct_declarator '(' parameter_type_list ')' { $$ = $1; }
+	| direct_declarator '(' identifier_list ')' { $$ = $1; }
+	| direct_declarator '(' ')' { $$ = $1; }
+	;
+
+pointer
+	: '*'
+	| '*' type_qualifier_list
+	| '*' pointer
+	| '*' type_qualifier_list pointer
+	;
+
+type_qualifier_list
+	: type_qualifier
+	| type_qualifier_list type_qualifier
+	;
+
+
+parameter_type_list
+	: parameter_list
+	| parameter_list ',' ELLIPSIS
+	;
+
+parameter_list
+	: parameter_declaration
+	| parameter_list ',' parameter_declaration
+	;
+
+parameter_declaration
+	: declaration_specifiers declarator
+	| declaration_specifiers abstract_declarator
+	| declaration_specifiers
+	;
+
+identifier_list
+	: IDENTIFIER
+	| identifier_list ',' IDENTIFIER
+	;
+
+type_name
+	: specifier_qualifier_list
+	| specifier_qualifier_list abstract_declarator
+	;
+
+abstract_declarator
+	: pointer
+	| direct_abstract_declarator
+	| pointer direct_abstract_declarator
+	;
+
+direct_abstract_declarator
+	: '(' abstract_declarator ')'
+	| '[' ']'
+	| '[' constant_expression ']'
+	| direct_abstract_declarator '[' ']'
+	| direct_abstract_declarator '[' constant_expression ']'
+	| '(' ')'
+	| '(' parameter_type_list ')'
+	| direct_abstract_declarator '(' ')'
+	| direct_abstract_declarator '(' parameter_type_list ')'
+	;
+
+initializer
+	: assignment_expression
+	| '{' initializer_list '}'
+	| '{' initializer_list ',' '}'
+	;
+
+initializer_list
+	: initializer
+	| initializer_list ',' initializer
+	;
+
+statement
+	: labeled_statement
+	| compound_statement
+	| expression_statement
+	| selection_statement
+	| iteration_statement
+	| jump_statement
+	;
+
+labeled_statement
+	: IDENTIFIER ':' statement
+	| CASE constant_expression ':' statement
+	| DEFAULT ':' statement
+	;
+
+compound_statement
+	: '{' '}'
+	| '{' statement_list '}'
+	| '{' declaration_list '}'
+	| '{' declaration_list statement_list '}'
+	;
+
+declaration_list
+	: declaration
+	| declaration_list declaration
+	;
+
+statement_list
+	: statement
+	| statement_list statement
+	;
+
+expression_statement
+	: ';'
+	| expression ';'
+	;
+
+selection_statement
+	: IF '(' expression ')' statement
+	| IF '(' expression ')' statement ELSE statement
+	| SWITCH '(' expression ')' statement
+	;
+
+iteration_statement
+	: WHILE '(' expression ')' statement
+	| DO statement WHILE '(' expression ')' ';'
+	| FOR '(' expression_statement expression_statement ')' statement
+	| FOR '(' expression_statement expression_statement expression ')' statement
+	;
+
+jump_statement
+	: GOTO IDENTIFIER ';'
+	| CONTINUE ';'
+	| BREAK ';'
+	| RETURN ';'
+	| RETURN expression ';'
+	;
+
+translation_unit
+	: external_declaration {
+		g_root = $1;
+	}
+	| translation_unit external_declaration {
+		// TODO: fix to be vector
+		g_root = $2;
+	}
+	;
+
+external_declaration
+	: function_definition {
+		$$ = $1;
+	}
+	| declaration {
+		$$ = $1;
+	}
+	;
+
+function_definition
+	: declaration_specifiers declarator declaration_list compound_statement {
+		std::cerr << "Old K&R style function was parsed (1). This is not part of the tested specification." << std::endl;
+		exit(3);
+	}
+	| declaration_specifiers declarator compound_statement {
+		// Normal functions
+		std::cout << "Got normal function: " << *$2 << std::endl;
+		std::vector<ExpressionPtr> args;
+		$$ = new Function(*$2, args);
+	}
+	| declarator declaration_list compound_statement {
+		std::cerr << "Old K&R style function was parsed (2). This is not part of the tested specification." << std::endl;
+		exit(3);
+	}
+	| declarator compound_statement {
+		// Function without a return type
+	}
+	;
+
+%%
+#include <stdio.h>
+
+extern char yytext[];
+extern int column;
+
+
+const Expression *g_root; // Definition of variable (to match declaration earlier)
+
+const Expression *parseAST()
+{
+	std::cout << "Parsing AST" << std::endl;
+    g_root=0;
+    yyparse();
+	std::cout << "yyparse done" << std::endl;
+    return g_root;
+}

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,13 +1,13 @@
 #include <cli.h>
 
-int parse_command_line_args(int argc, char **argv, std::string &sourcePath, std::string &outputPath)
+CommandLineArguments parse_command_line_args(int argc, char **argv)
 {
     std::string input = "";
 
     if ((argc <= 1) || (argv[argc - 1] == NULL) || (argv[argc - 1][0] == '-'))
     {
         std::cerr << "No command line arguments were provided" << std::endl;
-        return 1;
+        exit(1);
     }
     else
     {
@@ -17,17 +17,18 @@ int parse_command_line_args(int argc, char **argv, std::string &sourcePath, std:
     // Prevent opterr messages from being outputted.
     opterr = 0;
 
-    // bin/c_compiler -S [source-file.c] -o [dest-file.s]
+    // ./bin/c_compiler -S [source-file.c] -o [dest-file.s]
+    CommandLineArguments cliArgs;
     int opt;
     while ((opt = getopt(argc, argv, "S:o:")) != -1)
     {
         switch (opt)
         {
         case 'S':
-            sourcePath = std::string(optarg);
+            cliArgs.compileSourcePath = std::string(optarg);
             break;
         case 'o':
-            outputPath = std::string(optarg);
+            cliArgs.compileOutputPath = std::string(optarg);
             break;
         case '?':
             if (optopt == 'S' || optopt == 'o')
@@ -42,21 +43,22 @@ int parse_command_line_args(int argc, char **argv, std::string &sourcePath, std:
             {
                 fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
             }
-            return 1;
+            fprintf(stderr, "Exiting due to failure to parse CLI args\n");
+            exit(2);
         }
     }
 
-    if (sourcePath.length() == 0)
+    if (cliArgs.compileSourcePath.length() == 0)
     {
         std::cerr << "The source path -S argument was not set." << std::endl;
-        return 1;
+        exit(2);
     }
 
-    if (outputPath.length() == 0)
+    if (cliArgs.compileOutputPath.length() == 0)
     {
         std::cerr << "The output path -o argument was not set." << std::endl;
-        return 1;
+        exit(2);
     }
 
-    return 0;
+    return cliArgs;
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -48,10 +48,14 @@ int main(int argc, char **argv)
     prettyPrintOutput.close();
     std::cout << "Printed parsed AST to: " << prettyPrintOutputPath << std::endl;
 
+    // Create a Context. This can be used to pass around information about
+    // what's currently being compiled (e.g. function scope and variable names).
+    Context ctx;
+
     // Compile from the root of the AST and output this to the compiledOutput
     // file.
     std::cout << "Compiling parsed AST..." << std::endl;
-    root->compile(compiledOutput);
+    root->compile(ctx, compiledOutput);
     compiledOutput.close();
     std::cout << "Compiled to: " << commandLineArguments.compileOutputPath << std::endl;
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -3,6 +3,7 @@
 #include <unistd.h>
 
 #include "cli.h"
+#include "ast.hpp"
 
 void compile(std::ostream &w)
 {
@@ -17,8 +18,7 @@ void compile(std::ostream &w)
     w << "ret" << std::endl;
 }
 
-// TODO: uncomment the below if you're using Flex/Bison.
-// extern FILE *yyin;
+extern FILE *yyin;
 
 int main(int argc, char **argv)
 {
@@ -30,15 +30,12 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    // TODO: uncomment the below lines if you're using Flex/Bison.
-    // This configures Flex to look at sourcePath instead of
-    // reading from stdin.
-    // yyin = fopen(sourcePath, "r");
-    // if (yyin == NULL)
-    // {
-    //     perror("Could not open source file");
-    //     return 1;
-    // }
+    yyin = fopen(sourcePath.c_str(), "r");
+    if (yyin == NULL)
+    {
+        perror("Could not open source file");
+        return 1;
+    }
 
     // Open the output file in truncation mode (to overwrite the contents)
     std::ofstream output;
@@ -46,7 +43,18 @@ int main(int argc, char **argv)
 
     // Compile the input
     std::cout << "Compiling: " << sourcePath << std::endl;
-    compile(output);
+
+    auto root = parseAST();
+    std::cout << "AST parsing complete" << std::endl;
+
+    if (root == nullptr)
+    {
+        std::cerr << "The root of the AST was a null pointer. Likely the root was never initialised correctly during parsing." << std::endl;
+        return 2;
+    }
+
+    root->print(output);
+
     std::cout << "Compiled to: " << outputPath << std::endl;
 
     output.close();

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -5,58 +5,57 @@
 #include "cli.h"
 #include "ast.hpp"
 
-void compile(std::ostream &w)
-{
-    w << ".text" << std::endl;
-    w << ".globl f" << std::endl;
-    w << std::endl;
-
-    w << "f:" << std::endl;
-    w << "addi  t0, zero, 0" << std::endl;
-    w << "addi  t0, t0,   5" << std::endl;
-    w << "add   a0, zero, t0" << std::endl;
-    w << "ret" << std::endl;
-}
-
 extern FILE *yyin;
 
 int main(int argc, char **argv)
 {
-    // Parse CLI arguments, to fetch the values of the source and output files.
-    std::string sourcePath = "";
-    std::string outputPath = "";
-    if (parse_command_line_args(argc, argv, sourcePath, outputPath))
-    {
-        return 1;
-    }
+    // Parse CLI arguments to fetch the source file to compile and the path to output to.
+    // This retrives [source-file.c] and [dest-file.s], when the compiler is invoked as follows:
+    // ./bin/c_compiler -S [source-file.c] -o [dest-file.s]
+    auto commandLineArguments = parse_command_line_args(argc, argv);
 
-    yyin = fopen(sourcePath.c_str(), "r");
+    // Configure Flex to read from the compileSourcePath file instead of reading from stdin.
+    yyin = fopen(commandLineArguments.compileSourcePath.c_str(), "r");
     if (yyin == NULL)
     {
         perror("Could not open source file");
         return 1;
     }
 
-    // Open the output file in truncation mode (to overwrite the contents)
-    std::ofstream output;
-    output.open(outputPath, std::ios::trunc);
+    // Open the output files in truncation mode (to overwrite the contents)
+    std::ofstream compiledOutput, prettyPrintOutput;
+    compiledOutput.open(commandLineArguments.compileOutputPath, std::ios::trunc);
 
-    // Compile the input
-    std::cout << "Compiling: " << sourcePath << std::endl;
+    auto prettyPrintOutputPath = commandLineArguments.compileOutputPath + ".printed";
+    prettyPrintOutput.open(prettyPrintOutputPath, std::ios::trunc);
 
+    // Parse the input source file
+    std::cout << "Parsing: " << commandLineArguments.compileSourcePath << std::endl;
     auto root = parseAST();
     std::cout << "AST parsing complete" << std::endl;
 
     if (root == nullptr)
     {
+        // Check something was actually returned by parseAST().
         std::cerr << "The root of the AST was a null pointer. Likely the root was never initialised correctly during parsing." << std::endl;
-        return 2;
+        return 3;
     }
 
-    root->print(output);
+    // Output the pretty print version of what was parsed to the .printed output
+    // file.
+    std::cout << "Printing parsed AST..." << std::endl;
+    root->print(prettyPrintOutput);
+    prettyPrintOutput.close();
+    std::cout << "Printed parsed AST to: " << prettyPrintOutputPath << std::endl;
 
-    std::cout << "Compiled to: " << outputPath << std::endl;
+    // Compile from the root of the AST and output this to the compiledOutput
+    // file.
+    std::cout << "Compiling parsed AST..." << std::endl;
+    root->compile(compiledOutput);
+    compiledOutput.close();
+    std::cout << "Compiled to: " << commandLineArguments.compileOutputPath << std::endl;
 
-    output.close();
+    // Clean up afterwards.
+    delete root;
     return 0;
 }

--- a/test.sh
+++ b/test.sh
@@ -50,25 +50,25 @@ for DRIVER in compiler_tests/**/*_driver.c; do
     rm -f "${OUT}.s"
     rm -f "${OUT}.o"
     rm -f "${OUT}"
-    ./bin/c_compiler -S "${TO_ASSEMBLE}" -o "${OUT}.s" 2> "${LOG_PATH}.compiler.stderr.log" > "${LOG_PATH}.compiler.stdout.log"
+    timeout --foreground 15s  ./bin/c_compiler -S "${TO_ASSEMBLE}" -o "${OUT}.s" 2> "${LOG_PATH}.compiler.stderr.log" > "${LOG_PATH}.compiler.stdout.log"
     if [ $? -ne 0 ]; then
         fail_testcase "Fail: see ${LOG_PATH}.compiler.stderr.log and ${LOG_PATH}.compiler.stdout.log"
         continue
     fi
 
-    riscv64-unknown-elf-gcc -march=rv32imfd -mabi=ilp32d -o "${OUT}.o" -c "${OUT}.s" 2> "${LOG_PATH}.assembler.stderr.log" > "${LOG_PATH}.assembler.stdout.log"
+    timeout --foreground 15s riscv64-unknown-elf-gcc -march=rv32imfd -mabi=ilp32d -o "${OUT}.o" -c "${OUT}.s" 2> "${LOG_PATH}.assembler.stderr.log" > "${LOG_PATH}.assembler.stdout.log"
     if [ $? -ne 0 ]; then
         fail_testcase "Fail: see ${LOG_PATH}.assembler.stderr.log and ${LOG_PATH}.assembler.stdout.log"
         continue
     fi
 
-    riscv64-unknown-elf-gcc -march=rv32imfd -mabi=ilp32d -static -o "${OUT}" "${OUT}.o" "${DRIVER}" 2> "${LOG_PATH}.linker.stderr.log" > "${LOG_PATH}.linker.stdout.log"
+    timeout --foreground 15s riscv64-unknown-elf-gcc -march=rv32imfd -mabi=ilp32d -static -o "${OUT}" "${OUT}.o" "${DRIVER}" 2> "${LOG_PATH}.linker.stderr.log" > "${LOG_PATH}.linker.stdout.log"
     if [ $? -ne 0 ]; then
         fail_testcase "Fail: see ${LOG_PATH}.linker.stderr.log and ${LOG_PATH}.linker.stdout.log"
         continue
     fi
 
-    spike pk "${OUT}" > "${LOG_PATH}.simulation.log"
+    timeout --foreground 15s spike pk "${OUT}" > "${LOG_PATH}.simulation.log"
     if [ $? -eq 0 ]; then
         echo -e "\t> Pass"
         (( PASSING++ ))

--- a/test.sh
+++ b/test.sh
@@ -55,7 +55,7 @@ for DRIVER in compiler_tests/**/*_driver.c; do
     rm -f "${OUT}.s"
     rm -f "${OUT}.o"
     rm -f "${OUT}"
-    timeout --foreground 15s  ./bin/c_compiler -S "${TO_ASSEMBLE}" -o "${OUT}.s" 2> "${LOG_PATH}.compiler.stderr.log" > "${LOG_PATH}.compiler.stdout.log"
+    ASAN_OPTIONS=exitcode=0 timeout --foreground 15s  ./bin/c_compiler -S "${TO_ASSEMBLE}" -o "${OUT}.s" 2> "${LOG_PATH}.compiler.stderr.log" > "${LOG_PATH}.compiler.stdout.log"
     if [ $? -ne 0 ]; then
         fail_testcase "Fail: see ${LOG_PATH}.compiler.stderr.log and ${LOG_PATH}.compiler.stdout.log"
         continue

--- a/test.sh
+++ b/test.sh
@@ -13,11 +13,16 @@ if [ $# -eq 1 ]; then
     test $1 = "coverage"
     with_coverage=$?
 fi
+
 if [ $with_coverage -eq 0 ]; then
     rm -rf coverage
+    set -e
     make with_coverage
+    set +e
 else
+    set -e
     make bin/c_compiler
+    set +e
 fi
 
 mkdir -p bin

--- a/test.sh
+++ b/test.sh
@@ -45,42 +45,43 @@ for DRIVER in compiler_tests/**/*_driver.c; do
     (( TOTAL++ ))
 
     TO_ASSEMBLE="${DRIVER%_driver.c}.c"
-    LOG_PATH="${TO_ASSEMBLE//\//_}"
+    LOG_PATH="${TO_ASSEMBLE#compiler_tests/}"
     LOG_PATH="./bin/output/${LOG_PATH%.c}"
+    BASE_NAME="$(basename "${LOG_PATH}")"
+    LOG_FILE_BASE="${LOG_PATH}/${BASE_NAME}"
+    rm -rf "${LOG_PATH}"
+    mkdir -p "${LOG_PATH}"
 
     echo "${TO_ASSEMBLE}"
     printf '%s\n' "<testcase name=\"${TO_ASSEMBLE}\">" >> "${J_UNIT_OUTPUT_FILE}"
 
-    OUT="${LOG_PATH}"
-    rm -f "${OUT}.s"
-    rm -f "${OUT}.o"
-    rm -f "${OUT}"
-    ASAN_OPTIONS=exitcode=0 timeout --foreground 15s  ./bin/c_compiler -S "${TO_ASSEMBLE}" -o "${OUT}.s" 2> "${LOG_PATH}.compiler.stderr.log" > "${LOG_PATH}.compiler.stdout.log"
+    OUT="${LOG_FILE_BASE}"
+    ASAN_OPTIONS=exitcode=0 timeout --foreground 15s ./bin/c_compiler -S "${TO_ASSEMBLE}" -o "${OUT}.s" 2> "${LOG_FILE_BASE}.compiler.stderr.log" > "${LOG_FILE_BASE}.compiler.stdout.log"
     if [ $? -ne 0 ]; then
-        fail_testcase "Fail: see ${LOG_PATH}.compiler.stderr.log and ${LOG_PATH}.compiler.stdout.log"
+        fail_testcase "Failed to compile testcase: see ${LOG_FILE_BASE}.compiler.stderr.log and ${LOG_FILE_BASE}.compiler.stdout.log and ${OUT}.s"
         continue
     fi
 
-    timeout --foreground 15s riscv64-unknown-elf-gcc -march=rv32imfd -mabi=ilp32d -o "${OUT}.o" -c "${OUT}.s" 2> "${LOG_PATH}.assembler.stderr.log" > "${LOG_PATH}.assembler.stdout.log"
+    timeout --foreground 15s riscv64-unknown-elf-gcc -march=rv32imfd -mabi=ilp32d -o "${OUT}.o" -c "${OUT}.s" 2> "${LOG_FILE_BASE}.assembler.stderr.log" > "${LOG_FILE_BASE}.assembler.stdout.log"
     if [ $? -ne 0 ]; then
-        fail_testcase "Fail: see ${LOG_PATH}.assembler.stderr.log and ${LOG_PATH}.assembler.stdout.log"
+        fail_testcase "Failed to assemble: see ${LOG_FILE_BASE}.assembler.stderr.log and ${LOG_FILE_BASE}.assembler.stdout.log and ${OUT}.s"
         continue
     fi
 
-    timeout --foreground 15s riscv64-unknown-elf-gcc -march=rv32imfd -mabi=ilp32d -static -o "${OUT}" "${OUT}.o" "${DRIVER}" 2> "${LOG_PATH}.linker.stderr.log" > "${LOG_PATH}.linker.stdout.log"
+    timeout --foreground 15s riscv64-unknown-elf-gcc -march=rv32imfd -mabi=ilp32d -static -o "${OUT}" "${OUT}.o" "${DRIVER}" 2> "${LOG_FILE_BASE}.linker.stderr.log" > "${LOG_FILE_BASE}.linker.stdout.log"
     if [ $? -ne 0 ]; then
-        fail_testcase "Fail: see ${LOG_PATH}.linker.stderr.log and ${LOG_PATH}.linker.stdout.log"
+        fail_testcase "Failed to link driver: see ${LOG_FILE_BASE}.linker.stderr.log and ${LOG_FILE_BASE}.linker.stdout.log and ${OUT}.s"
         continue
     fi
 
-    timeout --foreground 15s spike pk "${OUT}" > "${LOG_PATH}.simulation.log"
+    timeout --foreground 15s spike pk "${OUT}" > "${LOG_FILE_BASE}.simulation.log"
     if [ $? -eq 0 ]; then
         echo -e "\t> Pass"
         (( PASSING++ ))
 
         printf '%s\n' "</testcase>" >> "${J_UNIT_OUTPUT_FILE}"
     else
-        fail_testcase "Fail: simulation did not exit with exit-code 0"
+        fail_testcase "Failed to simulate: simulation did not exit with exit-code 0, see ${LOG_FILE_BASE}.simulation.log and ${OUT}.s"
     fi
 done
 

--- a/toolchain_test.sh
+++ b/toolchain_test.sh
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 make bin/c_compiler
+rm -f bin/riscv_example.s
 ./bin/c_compiler -S "compiler_tests/_example/example.c" -o "bin/riscv_example.s"
 riscv64-unknown-elf-gcc -march=rv32imfd -mabi=ilp32d -o "bin/riscv_example" "bin/riscv_example.s" "compiler_tests/_example/example_driver.c"
 
@@ -18,5 +19,4 @@ else
 fi
 set -e
 
-rm bin/riscv_example
-rm bin/riscv_example.s
+rm -f bin/riscv_example


### PR DESCRIPTION
## What does this PR do?

- [x] Includes the Lab 2 AST files as a base for the compiler coursework (some modifications have been made for them to make sense, e.g. `evaluate()` has been changed to `compile()`)
- [x] Adds the C90 Flex and Bison files to the `src` folder
- [x] Adds `ExpressionList` class, which inherits from `Expression` and can be used to construct a list of expressions when parsing
- [x] Adds an empty `Context` class which is passed to `compile()` methods, to allow for data to be easily passed around during compilation if required.
- [x] Updates the Makefile to properly track all dependencies, meaning that people will no longer have to `make clean` then `make` when editing just the `hpp` files.
- [x] Improves the output of the testing scripts, such that it's obvious what stage fails during the test.
- [x] `Not implemented` messages are now logged to stderr
- [x] Adds `lcov` to the Docker image to be able to generate coverage
- [x] Improves the `.gitignore` to ignore Bison/Flex/coverage/.o files
- [x] Sets up ASAN logging to assist with debugging segfaults
- [x] Tidies up the environment docs
- [x] Improves command line argument handling as that was a bit confusing last year
- [x] Prevents the test script from continuing to run if `make` failed